### PR TITLE
Fix "ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead" error

### DIFF
--- a/app/api/players/[id]/route.ts
+++ b/app/api/players/[id]/route.ts
@@ -2,11 +2,13 @@ import joi from "joi"
 import { apiHandler } from "@/lib/server/api"
 import { playersRepo } from "@/lib/server"
 
-module.exports = apiHandler({
+const handlers = apiHandler({
   GET: getById,
   PUT: update,
   DELETE: _delete,
 })
+
+export const { GET, PUT, DELETE } = handlers
 
 interface Params {
   params: {

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -2,10 +2,12 @@ import joi from "joi"
 import { playersRepo } from "@/lib/server"
 import { apiHandler } from "@/lib/server/api"
 
-module.exports = apiHandler({
+const handlers = apiHandler({
   GET: getAll,
   POST: create,
 })
+
+export const { GET, POST } = handlers
 
 async function getAll() {
   return await playersRepo.getAll()


### PR DESCRIPTION
This PR addresses the "ES Modules may not assign module.exports or exports., Use ESM export syntax, instead" error that occurs within the codebase.